### PR TITLE
update image for organic arrows

### DIFF
--- a/src/js/data.json
+++ b/src/js/data.json
@@ -76,7 +76,7 @@
             "title": "Organic Arrows",
             "subtitle": "Lesson 2: Contour Lines, Texture and Construction",
             "detailsLink": "https://drawabox.com/lesson/2/organicarrows",
-            "exampleImage": "https://d15v304a6xpq4b.cloudfront.net/lesson_images/4e36a27a.jpg"
+            "exampleImage": "https://d15v304a6xpq4b.cloudfront.net/lesson_images/c3ee7097.jpg"
         },
         {
             "id": "2CL",


### PR DESCRIPTION
The one in the exercise has a mistake that was fixed (see the arrow in the top-left): https://drawabox.com/lesson/2/organicarrows